### PR TITLE
cmake: explicitly set CMAKE_CXX_STANDARD to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SERVER_INSTALL_DIR "bin" CACHE STRING "Server library path relative to game 
 set(CLIENT_INSTALL_DIR "bin" CACHE STRING "Client library path relative to game directory")
 set(UTILS_INSTALL_DIR "devkit" CACHE STRING "Utilities path relative to game directory")
 set(SERVER_LIBRARY_NAME "server" CACHE STRING "Library name for Linux/MacOS/Windows")
+set(CMAKE_CXX_STANDARD 14)
 
 if(BUILD_CLIENT)
 	list(APPEND VCPKG_MANIFEST_FEATURES "client")


### PR DESCRIPTION
Not sure if it's supposed to be C++14 but setting this variable explicitly partially fixes the building issue on macOS (thanks @FiEctro for help). It's also a good idea in general to tell the compiler which standard version is being used.