### PR TITLE
game_shared: include malloc.h on win32, otherwise use alloca.h

### DIFF
--- a/game_shared/utlmemory.h
+++ b/game_shared/utlmemory.h
@@ -16,7 +16,11 @@
 
 #include <stddef.h>
 #include <string.h>
+#ifdef _WIN32
 #include <malloc.h>
+#else // _WIN32
+#include <alloca.h>
+#endif // _WIN32
 #include <new>
 
 #define ALIGN_VALUE( val, alignment )	(( val + alignment - 1 ) & ~( alignment - 1 ))


### PR DESCRIPTION
alloca() is a nonstandard function, and its definition location depends on the platform.

Ideally, we test which header defines it, on Win32 it's malloc.h as per the documentation, on *nixes it's usually alloca.h, but sometimes it's even stdlib.h.

For now, just include alloca.h to fix building on macOS (thanks @FiEctro for the help!)