### PR TITLE
Initial implementation of weapon prediction

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND SVDLL_SOURCES
 	"user_messages.cpp"
 	"util.cpp"
 	"weapons.cpp"
+	"weapon_logic.cpp"
 	"world.cpp"
 )
 

--- a/server/weapon_logic.cpp
+++ b/server/weapon_logic.cpp
@@ -1,0 +1,220 @@
+#include "weapon_logic.h"
+
+void CBaseWeaponLogic::ItemPostFrame()
+{
+	if ((m_fInReload) && ( m_pPlayer->m_flNextAttack <= gpGlobals->time ))
+	{
+		// complete the reload. 
+		int j = Q_min( iMaxClip() - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);	
+
+		// Add them to the clip
+		m_iClip += j;
+		m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
+
+		m_fInReload = FALSE;
+	}
+
+	if ((m_pPlayer->pev->button & IN_ATTACK2) && CanAttack( m_flNextSecondaryAttack, gpGlobals->time, UseDecrement() ) )
+	{
+		if ( pszAmmo2() && !m_pPlayer->m_rgAmmo[SecondaryAmmoIndex()] )
+		{
+			m_fFireOnEmpty = TRUE;
+		}
+
+		SecondaryAttack();
+		m_pPlayer->pev->button &= ~IN_ATTACK2;
+	}
+	else if ((m_pPlayer->pev->button & IN_ATTACK) && CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ) )
+	{
+		if ( (m_iClip == 0 && pszAmmo1()) || (iMaxClip() == -1 && !m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] ) )
+		{
+			m_fFireOnEmpty = TRUE;
+		}
+
+		PrimaryAttack();
+	}
+	else if ( m_pPlayer->pev->button & IN_RELOAD && iMaxClip() != WEAPON_NOCLIP && !m_fInReload ) 
+	{
+		// reload when reload is pressed, or if no buttons are down and weapon is empty.
+		Reload();
+	}
+	else if ( !(m_pPlayer->pev->button & (IN_ATTACK|IN_ATTACK2) ) )
+	{
+		// no fire buttons down
+
+		m_fFireOnEmpty = FALSE;
+
+		if ( !IsUseable() && m_flNextPrimaryAttack < ( UseDecrement() ? 0.0 : gpGlobals->time ) ) 
+		{
+			// weapon isn't useable, switch.
+			if ( !(iFlags() & ITEM_FLAG_NOAUTOSWITCHEMPTY) && g_pGameRules->GetNextBestWeapon( m_pPlayer, this ) )
+			{
+				m_flNextPrimaryAttack = ( UseDecrement() ? 0.0 : gpGlobals->time ) + 0.3;
+				return;
+			}
+		}
+		else
+		{
+			// weapon is useable. Reload if empty and weapon has waited as long as it has to after firing
+			if ( m_iClip == 0 && !(iFlags() & ITEM_FLAG_NOAUTORELOAD) && m_flNextPrimaryAttack < ( UseDecrement() ? 0.0 : gpGlobals->time ) )
+			{
+				Reload();
+				return;
+			}
+		}
+
+		WeaponIdle( );
+		return;
+	}
+	
+	// catch all
+	if ( ShouldWeaponIdle() )
+	{
+		WeaponIdle();
+	}
+}
+
+void CBaseWeaponLogic::Holster( void )
+{ 
+	m_fInReload = FALSE; // cancel any reload in progress.
+	m_pPlayer->pev->viewmodel = 0; 
+	m_pPlayer->pev->weaponmodel = 0;
+}
+
+//=========================================================
+// IsUseable - this function determines whether or not a 
+// weapon is useable by the player in its current state. 
+// (does it have ammo loaded? do I have any ammo for the 
+// weapon?, etc)
+//=========================================================
+BOOL CBaseWeaponLogic :: IsUseable( void )
+{
+	if ( m_iClip <= 0 )
+	{
+		if ( m_pPlayer->m_rgAmmo[ PrimaryAmmoIndex() ] <= 0 && iMaxAmmo1() != -1 )			
+		{
+			// clip is empty (or nonexistant) and the player has no more ammo of this type. 
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+BOOL CBaseWeaponLogic :: CanDeploy( void )
+{
+	BOOL bHasAmmo = 0;
+
+	if ( !pszAmmo1() )
+	{
+		// this weapon doesn't use ammo, can always deploy.
+		return TRUE;
+	}
+
+	if ( pszAmmo1() )
+	{
+		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0);
+	}
+	if ( pszAmmo2() )
+	{
+		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iSecondaryAmmoType] != 0);
+	}
+	if (m_iClip > 0)
+	{
+		bHasAmmo |= 1;
+	}
+	if (!bHasAmmo)
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+BOOL CBaseWeaponLogic :: DefaultDeploy( char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal /* = 0 */, int body )
+{
+	if (!CanDeploy( ))
+		return FALSE;
+
+	m_pPlayer->pev->viewmodel = MAKE_STRING(szViewModel);
+	m_pPlayer->pev->weaponmodel = MAKE_STRING(szWeaponModel);
+	strcpy( m_pPlayer->m_szAnimExtention, szAnimExt );
+	SendWeaponAnim( iAnim, skiplocal, body );
+
+	m_pPlayer->m_flNextAttack = gpGlobals->time + 0.5;
+	m_flTimeWeaponIdle = gpGlobals->time + 1.0;
+
+	return TRUE;
+}
+
+BOOL CBaseWeaponLogic :: DefaultReload( int iClipSize, int iAnim, float fDelay, int body )
+{
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
+		return FALSE;
+
+	int j = Q_min(iClipSize - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);	
+
+	if (j == 0)
+		return FALSE;
+
+	m_pPlayer->m_flNextAttack = gpGlobals->time + fDelay;
+
+	//!!UNDONE -- reload sound goes here !!!
+	SendWeaponAnim( iAnim, UseDecrement() ? 1 : 0 );
+
+	m_fInReload = TRUE;
+
+	m_flTimeWeaponIdle = gpGlobals->time + 3;
+	return TRUE;
+}
+
+void CBaseWeaponLogic::SendWeaponAnim( int iAnim, int skiplocal, int body )
+{
+	if ( UseDecrement() )
+		skiplocal = 1;
+	else
+		skiplocal = 0;
+
+	m_pPlayer->pev->weaponanim = iAnim;
+
+	MESSAGE_BEGIN( MSG_ONE, SVC_WEAPONANIM, NULL, m_pPlayer->pev );
+		WRITE_BYTE( iAnim );						// sequence number
+		WRITE_BYTE( pev->body );					// weaponmodel bodygroup.
+	MESSAGE_END();
+}
+
+BOOL CBaseWeaponLogic :: PlayEmptySound( void )
+{
+	if (m_iPlayEmptySound)
+	{
+		EMIT_SOUND(ENT(m_pPlayer->pev), CHAN_WEAPON, "weapons/357_cock1.wav", 0.8, ATTN_NORM);
+		m_iPlayEmptySound = 0;
+		return 0;
+	}
+	return 0;
+}
+
+void CBaseWeaponLogic :: ResetEmptySound( void )
+{
+	m_iPlayEmptySound = 1;
+}
+
+int CBaseWeaponLogic::PrimaryAmmoIndex( void )
+{
+	return m_iPrimaryAmmoType;
+}
+
+int CBaseWeaponLogic::SecondaryAmmoIndex( void )
+{
+	return -1;
+}
+
+int	CBaseWeaponLogic::iItemPosition( void ) 		{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iPosition; }
+const char *CBaseWeaponLogic::pszAmmo1( void ) 		{ return CBasePlayerItem::ItemInfoArray[ m_iId ].pszAmmo1; }
+int CBaseWeaponLogic::iMaxAmmo1( void ) 			{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iMaxAmmo1; }
+const char *CBaseWeaponLogic::pszAmmo2( void ) 		{ return CBasePlayerItem::ItemInfoArray[ m_iId ].pszAmmo2; }
+int	CBaseWeaponLogic::iMaxAmmo2( void ) 			{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iMaxAmmo2; }
+const char *CBaseWeaponLogic::pszName( void ) 		{ return CBasePlayerItem::ItemInfoArray[ m_iId ].pszName; }
+int	CBaseWeaponLogic::iMaxClip( void ) 				{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iMaxClip; }
+int	CBaseWeaponLogic::iWeight( void ) 				{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iWeight; }
+int CBaseWeaponLogic::iFlags( void ) 				{ return CBasePlayerItem::ItemInfoArray[ m_iId ].iFlags; }

--- a/server/weapon_logic.h
+++ b/server/weapon_logic.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "vector.h"
+#include "weapons.h"
+
+class CBaseWeaponLogic
+{
+public:
+	void ItemPostFrame();
+
+	// called by CBasePlayerWeapons ItemPostFrame()
+	virtual void PrimaryAttack( void ) { return; }				// do "+ATTACK"
+	virtual void SecondaryAttack( void ) { return; }			// do "+ATTACK2"
+	virtual void Reload( void ) { return; }						// do "+RELOAD"
+	virtual void WeaponIdle( void ) { return; }					// called when no buttons pressed
+
+	virtual BOOL ShouldWeaponIdle( void ) {return FALSE; };
+	virtual BOOL CanDeploy( void ) { return TRUE; };
+	virtual BOOL Deploy( ) { return TRUE; };		// returns is deploy was successful	 
+	virtual BOOL CanHolster( void ) { return TRUE; };		// can this weapon be put away right nxow?
+	virtual void Holster(void) {};
+	virtual BOOL IsUseable( void );
+	virtual BOOL UseDecrement( void ) { return FALSE; };
+	
+	virtual int GetItemInfo(ItemInfo *p) { return 0; };	// returns 0 if struct not filled out
+	virtual int	PrimaryAmmoIndex(); 
+	virtual int	SecondaryAmmoIndex(); 
+
+	virtual int	iItemPosition(void);
+	virtual const char *pszAmmo1(void);
+	virtual int iMaxAmmo1(void);
+	virtual const char *pszAmmo2(void);
+	virtual int	iMaxAmmo2(void);
+	virtual const char *pszName(void);
+	virtual int	iMaxClip(void);
+	virtual int	iWeight(void);
+	virtual	int iFlags(void);
+
+	BOOL DefaultDeploy( char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal = 0, int body = 0 );
+	int DefaultReload( int iClipSize, int iAnim, float fDelay, int body = 0 );
+	void SendWeaponAnim( int iAnim, int skiplocal = 1, int body = 0 );  // skiplocal is 1 if client is predicting weapon animations
+	BOOL PlayEmptySound( void );
+	void ResetEmptySound( void );
+
+	int	m_iId;				// WEAPON_???
+	int m_iPlayEmptySound;
+	int m_fFireOnEmpty;		// True when the gun is empty and the player is still holding down the attack key(s)
+	float m_flPumpTime;
+	int	m_fInSpecialReload;			// Are we in the middle of a reload for the shotguns
+	float m_flNextPrimaryAttack;		// soonest time ItemPostFrame will call PrimaryAttack
+	float m_flNextSecondaryAttack;		// soonest time ItemPostFrame will call SecondaryAttack
+	float m_flTimeWeaponIdle;			// soonest time ItemPostFrame will call WeaponIdle
+	int	m_iPrimaryAmmoType;			// "primary" ammo index into players m_rgAmmo[]
+	int	m_iSecondaryAmmoType;		// "secondary" ammo index into players m_rgAmmo[]
+	int	m_iClip;				// number of shots left in the primary weapon clip, -1 it not used
+	int	m_iClientClip;			// the last version of m_iClip sent to hud dll
+	int	m_iClientWeaponState;		// the last version of the weapon state sent to hud dll (is current weapon, is on target)
+	int	m_fInReload;			// Are we in the middle of a reload;
+	int	m_iDefaultAmmo;// how much ammo you get when you pick up this weapon as placed by a level designer.
+};
+

--- a/server/weapons.cpp
+++ b/server/weapons.cpp
@@ -398,7 +398,6 @@ void W_Precache(void)
 BEGIN_DATADESC( CBasePlayerItem )
 	DEFINE_FIELD( m_pPlayer, FIELD_CLASSPTR ),
 	DEFINE_FIELD( m_pNext, FIELD_CLASSPTR ),
-	DEFINE_FIELD( m_iId, FIELD_INTEGER ),
 	DEFINE_FUNCTION( DestroyItem ),
 	DEFINE_FUNCTION( DefaultTouch ),
 	DEFINE_FUNCTION( FallThink ),
@@ -414,6 +413,7 @@ BEGIN_DATADESC( CBasePlayerWeapon )
 	DEFINE_FIELD( m_iSecondaryAmmoType, FIELD_INTEGER ),
 	DEFINE_FIELD( m_iClip, FIELD_INTEGER ),
 	DEFINE_FIELD( m_iDefaultAmmo, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iId, FIELD_INTEGER ),
 END_DATADESC()
 
 void CBasePlayerItem :: SetObjectCollisionBox( void )
@@ -591,76 +591,7 @@ BOOL CanAttack( float attack_time, float curtime, BOOL isPredicted )
 
 void CBasePlayerWeapon::ItemPostFrame( void )
 {
-	if ((m_fInReload) && ( m_pPlayer->m_flNextAttack <= gpGlobals->time ))
-	{
-		// complete the reload. 
-		int j = Q_min( iMaxClip() - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);	
 
-		// Add them to the clip
-		m_iClip += j;
-		m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= j;
-
-		m_fInReload = FALSE;
-	}
-
-	if ((m_pPlayer->pev->button & IN_ATTACK2) && CanAttack( m_flNextSecondaryAttack, gpGlobals->time, UseDecrement() ) )
-	{
-		if ( pszAmmo2() && !m_pPlayer->m_rgAmmo[SecondaryAmmoIndex()] )
-		{
-			m_fFireOnEmpty = TRUE;
-		}
-
-		SecondaryAttack();
-		m_pPlayer->pev->button &= ~IN_ATTACK2;
-	}
-	else if ((m_pPlayer->pev->button & IN_ATTACK) && CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ) )
-	{
-		if ( (m_iClip == 0 && pszAmmo1()) || (iMaxClip() == -1 && !m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] ) )
-		{
-			m_fFireOnEmpty = TRUE;
-		}
-
-		PrimaryAttack();
-	}
-	else if ( m_pPlayer->pev->button & IN_RELOAD && iMaxClip() != WEAPON_NOCLIP && !m_fInReload ) 
-	{
-		// reload when reload is pressed, or if no buttons are down and weapon is empty.
-		Reload();
-	}
-	else if ( !(m_pPlayer->pev->button & (IN_ATTACK|IN_ATTACK2) ) )
-	{
-		// no fire buttons down
-
-		m_fFireOnEmpty = FALSE;
-
-		if ( !IsUseable() && m_flNextPrimaryAttack < ( UseDecrement() ? 0.0 : gpGlobals->time ) ) 
-		{
-			// weapon isn't useable, switch.
-			if ( !(iFlags() & ITEM_FLAG_NOAUTOSWITCHEMPTY) && g_pGameRules->GetNextBestWeapon( m_pPlayer, this ) )
-			{
-				m_flNextPrimaryAttack = ( UseDecrement() ? 0.0 : gpGlobals->time ) + 0.3;
-				return;
-			}
-		}
-		else
-		{
-			// weapon is useable. Reload if empty and weapon has waited as long as it has to after firing
-			if ( m_iClip == 0 && !(iFlags() & ITEM_FLAG_NOAUTORELOAD) && m_flNextPrimaryAttack < ( UseDecrement() ? 0.0 : gpGlobals->time ) )
-			{
-				Reload();
-				return;
-			}
-		}
-
-		WeaponIdle( );
-		return;
-	}
-	
-	// catch all
-	if ( ShouldWeaponIdle() )
-	{
-		WeaponIdle();
-	}
 }
 
 void CBasePlayerItem::DestroyItem( void )
@@ -805,22 +736,6 @@ int CBasePlayerWeapon::UpdateClientData( CBasePlayer *pPlayer )
 	return 1;
 }
 
-
-void CBasePlayerWeapon::SendWeaponAnim( int iAnim, int skiplocal, int body )
-{
-	if ( UseDecrement() )
-		skiplocal = 1;
-	else
-		skiplocal = 0;
-
-	m_pPlayer->pev->weaponanim = iAnim;
-
-	MESSAGE_BEGIN( MSG_ONE, SVC_WEAPONANIM, NULL, m_pPlayer->pev );
-		WRITE_BYTE( iAnim );						// sequence number
-		WRITE_BYTE( pev->body );					// weaponmodel bodygroup.
-	MESSAGE_END();
-}
-
 BOOL CBasePlayerWeapon :: AddPrimaryAmmo( int iCount, char *szName, int iMaxClip, int iMaxCarry )
 {
 	int iIdAmmo;
@@ -873,131 +788,6 @@ BOOL CBasePlayerWeapon :: AddSecondaryAmmo( int iCount, char *szName, int iMax )
 		EMIT_SOUND(ENT(pev), CHAN_ITEM, "items/9mmclip1.wav", 1, ATTN_NORM);
 	}
 	return iIdAmmo > 0 ? TRUE : FALSE;
-}
-
-//=========================================================
-// IsUseable - this function determines whether or not a 
-// weapon is useable by the player in its current state. 
-// (does it have ammo loaded? do I have any ammo for the 
-// weapon?, etc)
-//=========================================================
-BOOL CBasePlayerWeapon :: IsUseable( void )
-{
-	if ( m_iClip <= 0 )
-	{
-		if ( m_pPlayer->m_rgAmmo[ PrimaryAmmoIndex() ] <= 0 && iMaxAmmo1() != -1 )			
-		{
-			// clip is empty (or nonexistant) and the player has no more ammo of this type. 
-			return FALSE;
-		}
-	}
-
-	return TRUE;
-}
-
-BOOL CBasePlayerWeapon :: CanDeploy( void )
-{
-	BOOL bHasAmmo = 0;
-
-	if ( !pszAmmo1() )
-	{
-		// this weapon doesn't use ammo, can always deploy.
-		return TRUE;
-	}
-
-	if ( pszAmmo1() )
-	{
-		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] != 0);
-	}
-	if ( pszAmmo2() )
-	{
-		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iSecondaryAmmoType] != 0);
-	}
-	if (m_iClip > 0)
-	{
-		bHasAmmo |= 1;
-	}
-	if (!bHasAmmo)
-	{
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
-BOOL CBasePlayerWeapon :: DefaultDeploy( char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal /* = 0 */, int body )
-{
-	if (!CanDeploy( ))
-		return FALSE;
-
-	m_pPlayer->pev->viewmodel = MAKE_STRING(szViewModel);
-	m_pPlayer->pev->weaponmodel = MAKE_STRING(szWeaponModel);
-	strcpy( m_pPlayer->m_szAnimExtention, szAnimExt );
-	SendWeaponAnim( iAnim, skiplocal, body );
-
-	m_pPlayer->m_flNextAttack = gpGlobals->time + 0.5;
-	m_flTimeWeaponIdle = gpGlobals->time + 1.0;
-
-	return TRUE;
-}
-
-
-BOOL CBasePlayerWeapon :: DefaultReload( int iClipSize, int iAnim, float fDelay, int body )
-{
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-		return FALSE;
-
-	int j = Q_min(iClipSize - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);	
-
-	if (j == 0)
-		return FALSE;
-
-	m_pPlayer->m_flNextAttack = gpGlobals->time + fDelay;
-
-	//!!UNDONE -- reload sound goes here !!!
-	SendWeaponAnim( iAnim, UseDecrement() ? 1 : 0 );
-
-	m_fInReload = TRUE;
-
-	m_flTimeWeaponIdle = gpGlobals->time + 3;
-	return TRUE;
-}
-
-BOOL CBasePlayerWeapon :: PlayEmptySound( void )
-{
-	if (m_iPlayEmptySound)
-	{
-		EMIT_SOUND(ENT(m_pPlayer->pev), CHAN_WEAPON, "weapons/357_cock1.wav", 0.8, ATTN_NORM);
-		m_iPlayEmptySound = 0;
-		return 0;
-	}
-	return 0;
-}
-
-void CBasePlayerWeapon :: ResetEmptySound( void )
-{
-	m_iPlayEmptySound = 1;
-}
-
-//=========================================================
-//=========================================================
-int CBasePlayerWeapon::PrimaryAmmoIndex( void )
-{
-	return m_iPrimaryAmmoType;
-}
-
-//=========================================================
-//=========================================================
-int CBasePlayerWeapon::SecondaryAmmoIndex( void )
-{
-	return -1;
-}
-
-void CBasePlayerWeapon::Holster( void )
-{ 
-	m_fInReload = FALSE; // cancel any reload in progress.
-	m_pPlayer->pev->viewmodel = 0; 
-	m_pPlayer->pev->weaponmodel = 0;
 }
 
 BEGIN_DATADESC( CBasePlayerAmmo )
@@ -1465,17 +1255,17 @@ void CWeaponBox::SetObjectCollisionBox( void )
 
 void CBasePlayerWeapon::PrintState( void )
 {
-	ALERT( at_console, "primary:  %f\n", m_flNextPrimaryAttack );
-	ALERT( at_console, "idle   :  %f\n", m_flTimeWeaponIdle );
+//	ALERT( at_console, "primary:  %f\n", m_flNextPrimaryAttack );
+//	ALERT( at_console, "idle   :  %f\n", m_flTimeWeaponIdle );
 
 //	ALERT( at_console, "nextrl :  %f\n", m_flNextReload );
 //	ALERT( at_console, "nextpum:  %f\n", m_flPumpTime );
 
 //	ALERT( at_console, "m_frt  :  %f\n", m_fReloadTime );
-	ALERT( at_console, "m_finre:  %i\n", m_fInReload );
+//	ALERT( at_console, "m_finre:  %i\n", m_fInReload );
 //	ALERT( at_console, "m_finsr:  %i\n", m_fInSpecialReload );
 
-	ALERT( at_console, "m_iclip:  %i\n", m_iClip );
+//	ALERT( at_console, "m_iclip:  %i\n", m_iClip );
 }
 
 //=========================================================

--- a/server/weapons.h
+++ b/server/weapons.h
@@ -198,8 +198,7 @@ public:
 	virtual BOOL CanDeploy( void ) { return TRUE; };
 	virtual BOOL Deploy( ) { return TRUE; };		// returns is deploy was successful
 		 
-
-	virtual BOOL CanHolster( void ) { return TRUE; };		// can this weapon be put away right now?
+	virtual BOOL CanHolster( void ) { return TRUE; };		// can this weapon be put away right nxow?
 	virtual void Holster( void );
 	virtual void UpdateItemInfo( void ) { return; };
 
@@ -222,19 +221,18 @@ public:
 
 	CBasePlayer	*m_pPlayer;
 	CBasePlayerItem	*m_pNext;
-	int		m_iId;				// WEAPON_???
 
 	virtual int iItemSlot( void ) { return 0; }		// return 0 to MAX_ITEMS_SLOTS, used in hud
 
-	int		iItemPosition( void ) { return ItemInfoArray[ m_iId ].iPosition; }
-	const char	*pszAmmo1( void )	{ return ItemInfoArray[ m_iId ].pszAmmo1; }
-	int		iMaxAmmo1( void )	{ return ItemInfoArray[ m_iId ].iMaxAmmo1; }
-	const char	*pszAmmo2( void )	{ return ItemInfoArray[ m_iId ].pszAmmo2; }
-	int		iMaxAmmo2( void )	{ return ItemInfoArray[ m_iId ].iMaxAmmo2; }
-	const char	*pszName( void )	{ return ItemInfoArray[ m_iId ].pszName; }
-	int		iMaxClip( void )	{ return ItemInfoArray[ m_iId ].iMaxClip; }
-	int		iWeight( void )	{ return ItemInfoArray[ m_iId ].iWeight; }
-	int		iFlags( void )	{ return ItemInfoArray[ m_iId ].iFlags; }
+	virtual int		iItemPosition(void) = 0;
+	virtual const char	*pszAmmo1(void) = 0;
+	virtual int		iMaxAmmo1(void) = 0;
+	virtual const char	*pszAmmo2(void) = 0;
+	virtual int		iMaxAmmo2(void) = 0;
+	virtual const char	*pszName(void) = 0;
+	virtual int		iMaxClip(void) = 0;
+	virtual int		iWeight(void) = 0;
+	virtual int		iFlags(void) = 0;
 };
 
 // inventory items that 
@@ -245,66 +243,49 @@ public:
 	DECLARE_DATADESC();
 
 	// generic weapon versions of CBasePlayerItem calls
-	virtual int AddToPlayer( CBasePlayer *pPlayer );
-	virtual int AddDuplicate( CBasePlayerItem *pItem );
+	virtual int AddToPlayer( CBasePlayer *pPlayer ) override; 
+	virtual int AddDuplicate( CBasePlayerItem *pItem ) override;
+	
+	int UpdateClientData( CBasePlayer *pPlayer ) override;				// sends hud info to client dll, if things have changed
 
-	virtual int ExtractAmmo( CBasePlayerWeapon *pWeapon );		// Return TRUE if you can add ammo to yourself when picked up
-	virtual int ExtractClipAmmo( CBasePlayerWeapon *pWeapon );		// Return TRUE if you can add ammo to yourself when picked up
+	// forward to weapon logic
+	virtual void ItemPostFrame( void ) override;	// called each frame by the player PostThink
 
-	virtual int AddWeapon( void ) { ExtractAmmo( this ); return TRUE; };	// Return TRUE if you want to add yourself to the player
+	int	PrimaryAmmoIndex() override; // forward to weapon logic
+	int	SecondaryAmmoIndex() override; // forward to weapon logic
+
+	// forward all this to weapon logic
+	virtual int GetItemInfo(ItemInfo *p) override { return 0; };	// returns 0 if struct not filled out
+	virtual BOOL CanDeploy( void ) override { return TRUE; };
+	virtual BOOL Deploy( ) override { return TRUE; };		// returns is deploy was successful	 
+	virtual BOOL CanHolster( void ) override { return TRUE; };		// can this weapon be put away right nxow?
+	virtual void Holster(void) override {};
+
+	void UpdateItemInfo( void ) override {};	// updates HUD state
+	CBasePlayerItem *GetWeaponPtr( void ) override { return (CBasePlayerItem *)this; };
+
+	// forward all of them to weapon logic
+	int	iItemPosition( void ) override		{ return ItemInfoArray[ m_iId ].iPosition; }
+	const char *pszAmmo1( void ) override	{ return ItemInfoArray[ m_iId ].pszAmmo1; }
+	int iMaxAmmo1( void ) override			{ return ItemInfoArray[ m_iId ].iMaxAmmo1; }
+	const char *pszAmmo2( void ) override	{ return ItemInfoArray[ m_iId ].pszAmmo2; }
+	int	iMaxAmmo2( void ) override			{ return ItemInfoArray[ m_iId ].iMaxAmmo2; }
+	const char *pszName( void ) override	{ return ItemInfoArray[ m_iId ].pszName; }
+	int	iMaxClip( void ) override			{ return ItemInfoArray[ m_iId ].iMaxClip; }
+	int	iWeight( void ) override			{ return ItemInfoArray[ m_iId ].iWeight; }
+	int	iFlags( void ) override				{ return ItemInfoArray[ m_iId ].iFlags; }
+
+protected:
+	int ExtractAmmo( CBasePlayerWeapon *pWeapon );		// Return TRUE if you can add ammo to yourself when picked up
+	int ExtractClipAmmo( CBasePlayerWeapon *pWeapon );		// Return TRUE if you can add ammo to yourself when picked up
+
+	int AddWeapon( void ) { ExtractAmmo( this ); return TRUE; };	// Return TRUE if you want to add yourself to the player
+	void RetireWeapon( void );
 
 	// generic "shared" ammo handlers
 	BOOL AddPrimaryAmmo( int iCount, char *szName, int iMaxClip, int iMaxCarry );
 	BOOL AddSecondaryAmmo( int iCount, char *szName, int iMaxCarry );
-
-	virtual void UpdateItemInfo( void ) {};	// updates HUD state
-
-	int m_iPlayEmptySound;
-	int m_fFireOnEmpty;		// True when the gun is empty and the player is still holding down the
-							// attack key(s)
-	virtual BOOL PlayEmptySound( void );
-	virtual void ResetEmptySound( void );
-
-	virtual void SendWeaponAnim( int iAnim, int skiplocal = 1, int body = 0 );  // skiplocal is 1 if client is predicting weapon animations
-
-	virtual BOOL CanDeploy( void );
-	virtual BOOL IsUseable( void );
-	BOOL DefaultDeploy( char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal = 0, int body = 0 );
-	int DefaultReload( int iClipSize, int iAnim, float fDelay, int body = 0 );
-
-	virtual void ItemPostFrame( void );	// called each frame by the player PostThink
-	// called by CBasePlayerWeapons ItemPostFrame()
-	virtual void PrimaryAttack( void ) { return; }				// do "+ATTACK"
-	virtual void SecondaryAttack( void ) { return; }			// do "+ATTACK2"
-	virtual void Reload( void ) { return; }						// do "+RELOAD"
-	virtual void WeaponIdle( void ) { return; }					// called when no buttons pressed
-	virtual int UpdateClientData( CBasePlayer *pPlayer );		// sends hud info to client dll, if things have changed
-	virtual void RetireWeapon( void );
-	virtual BOOL ShouldWeaponIdle( void ) {return FALSE; };
-	virtual void Holster( void );
-	virtual BOOL UseDecrement( void ) { return FALSE; };
-	
-	int	PrimaryAmmoIndex(); 
-	int	SecondaryAmmoIndex(); 
-
 	void PrintState( void );
-
-	virtual CBasePlayerItem *GetWeaponPtr( void ) { return (CBasePlayerItem *)this; };
-
-	float m_flPumpTime;
-	int	m_fInSpecialReload;			// Are we in the middle of a reload for the shotguns
-	float	m_flNextPrimaryAttack;		// soonest time ItemPostFrame will call PrimaryAttack
-	float	m_flNextSecondaryAttack;		// soonest time ItemPostFrame will call SecondaryAttack
-	float	m_flTimeWeaponIdle;			// soonest time ItemPostFrame will call WeaponIdle
-	int	m_iPrimaryAmmoType;			// "primary" ammo index into players m_rgAmmo[]
-	int	m_iSecondaryAmmoType;		// "secondary" ammo index into players m_rgAmmo[]
-	int	m_iClip;				// number of shots left in the primary weapon clip, -1 it not used
-	int	m_iClientClip;			// the last version of m_iClip sent to hud dll
-	int	m_iClientWeaponState;		// the last version of the weapon state sent to hud dll (is current weapon, is on target)
-	int	m_fInReload;			// Are we in the middle of a reload;
-
-	int	m_iDefaultAmmo;// how much ammo you get when you pick up this weapon as placed by a level designer.
-
 };
 
 class CBasePlayerAmmo : public CBaseEntity


### PR DESCRIPTION
```
ключевая идея такова, и состоит из нескольких шагов:
1) отделить весь код оружия от класса энтити оружия, вынести всю оружейную логику в серверсайдный CBaseWeaponLogic. класс энтити оружия должен иметь в себе только базовую инициализацию по типу задания модели и класснейма, ну и поинтер на CBaseWeaponLogic, через который будут прокидываться вызовы методов внутрь логики
2) далее, сделать код CBaseWeaponLogic компилируемым и на клиенте, и на сервере, отвязать его от серверсайдных классов/типов/функций
3) имплементировать на стороне клиента код предиктинга оружия. тут работа предстоит немаленькая.
4) как-то пофиксить save-restore у энтить оружия. как вариант, продублировать данные, которые требуется сохранить, в классе энтити оружия, а потом при загрузке/сохранении их записывать/читать из weapon logic объекта. в теории ничего в этом методе нерабочего нет, просто придётся на каждый класс писать кучку бойлерплейта.
```