### PR TITLE
pxrad: fix_coord fix

### DIFF
--- a/utils/common/mathlib.h
+++ b/utils/common/mathlib.h
@@ -229,13 +229,13 @@ _forceinline int ffsl( uint32_t mask )
 ==============
 fix_coord
 
-converts the reletive tex coords to absolute
+converts relative tex coords to absolute
 ==============
 */
 _forceinline uint fix_coord( vec_t in, uint width )
 {
 	if( in > 0 ) return (uint)in % width;
-	return width - ((uint)fabs( in ) % width);
+	return width - ((uint)fabsf( in ) % width) - 1;
 }
 
 bool VectorIsOnAxis( const vec3_t v );

--- a/utils/pxrad/raytracer.cpp
+++ b/utils/pxrad/raytracer.cpp
@@ -348,8 +348,8 @@ bool CWorldRayTrace :: TraceTexture( const tface_t *face, float u, float v, floa
 	float	t = w * mesh->verts[face->a].st[1] + u * mesh->verts[face->b].st[1] + v * mesh->verts[face->c].st[1];
 
 	// convert ST to real pixels position
-	int	x = fix_coord( s * face->texture->width, face->texture->width - 1 );
-	int	y = fix_coord( t * face->texture->height, face->texture->height - 1 );
+	int	x = fix_coord( s * face->texture->width, face->texture->width );
+	int	y = fix_coord( t * face->texture->height, face->texture->height );
 
 	// test pixel
 	if( face->texture->data[(face->texture->width * y) + x] != 255 )

--- a/utils/pxrad/studio.cpp
+++ b/utils/pxrad/studio.cpp
@@ -558,8 +558,8 @@ static int StudioCreateMeshFromTriangles( entity_t *ent, studiohdr_t *phdr, cons
 
 			if( extex )
 			{
-				int	x = fix_coord( s * extex->width, extex->width - 1 );
-				int	y = fix_coord( t * extex->height, extex->height - 1 );
+				int	x = fix_coord( s * extex->width, extex->width );
+				int	y = fix_coord( t * extex->height, extex->height );
 				
 				weight_sum++;
 				for( k = 0; k < 3; k++ )
@@ -567,8 +567,8 @@ static int StudioCreateMeshFromTriangles( entity_t *ent, studiohdr_t *phdr, cons
 			}
 			else
 			{
-				int	x = fix_coord( s * tex->width, tex->width - 1 );
-				int	y = fix_coord( t * tex->height, tex->height - 1 );	
+				int	x = fix_coord( s * tex->width, tex->width );
+				int	y = fix_coord( t * tex->height, tex->height );	
 
 				color_id = *((byte *)phdr + tex->index + tex->width * y + x);			
 

--- a/utils/pxrad/trace.cpp
+++ b/utils/pxrad/trace.cpp
@@ -68,8 +68,8 @@ int SampleMiptex( const dface_t *face, const vec3_t point )
 	dt = DotProduct( point, tx->vecs[1] ) + tx->vecs[1][3];
 
 	// convert ST to real pixels position
-	x = fix_coord( ds, mt->width - 1 );
-	y = fix_coord( dt, mt->height - 1 );
+	x = fix_coord( ds, mt->width );
+	y = fix_coord( dt, mt->height );
 
 	ASSERT( x >= 0 && y >= 0 );
 
@@ -261,8 +261,8 @@ void ClipMoveToTriangle( tface_t *face, moveclip_t *clip )
 		float t = w * clip->mesh->verts[face->a].st[1] + u * clip->mesh->verts[face->b].st[1] + v * clip->mesh->verts[face->c].st[1];
 
 		// convert ST to real pixels position
-		int x = fix_coord( s * face->texture->width, face->texture->width - 1 );
-		int y = fix_coord( t * face->texture->height, face->texture->height - 1 );
+		int x = fix_coord( s * face->texture->width, face->texture->width );
+		int y = fix_coord( t * face->texture->height, face->texture->height );
 
 		// test pixel
 		if( face->texture->data[(face->texture->width * y) + x] == 255 )


### PR DESCRIPTION
Fixed calculation of UV coordinates.
Fixed a crash when loading 1 pixel wide textures.